### PR TITLE
improve error handling/reporting

### DIFF
--- a/exporters/kinesisExporter.js
+++ b/exporters/kinesisExporter.js
@@ -9,35 +9,41 @@ function prepareRecord(data) {
 module.exports = function (args) {
   var firehose = new AWS.Firehose({ region: args.region });
 
-  this.add = function (record) {
+  this.add = function (record, callback) {
     var params = {
       Record: prepareRecord(record),
       DeliveryStreamName: args.streamName
     };
     firehose.putRecord(params, function (err, data) {
-      if (err) {
-        console.error('firehose err: ', err, data);
-      }
+      if (err) return callback(new Error('firehose err: ', err, data));
+      callback(null, 'sent record');
     });
   };
 
-  this.addBatch = function (records) {
+  this.addBatch = function (records, callback) {
     var batch = records.map(prepareRecord);
-    for (var i = 0; i < batch.length; i += 500) {
-      var curslice = batch.slice(i, i + 500);
+
+    function sendBatch(start) {
+      var curslice = batch.slice(start, start + 500);
       var params = {
         Records: curslice,
         DeliveryStreamName: args.streamName
       };
       firehose.putRecordBatch(params, function (err, response) {
-        if (err) return console.error('firehose err: ', err, response);
+        if (err) return callback(new Error('firehose err: ' + err + response));
         if (response.FailedPutCount > 0) {
-          return console.error(
-            'failed to send ' + response.FailedPutCount + ' of ' +
-            curslice.length + ' records. ', response);
+          console.error('failed to send ' + response.FailedPutCount + ' of ' +
+                        curslice.length + ' records. ', response);
         }
-        console.log('sent ' + curslice.length + ' records');
+
+        if (start + 500 < batch.length) {
+          sendBatch(start + 500);
+        } else {
+          callback(null, 'sent ' + batch.length + ' records');
+        }
       });
     }
+
+    sendBatch(0);
   };
 };

--- a/processors/lambdaS3.js
+++ b/processors/lambdaS3.js
@@ -13,46 +13,56 @@ module.exports = function (config) {
   var destPrefix = config.destPrefix;
 
   return function handler(event, context, callback) {
+    Error.stackTraceLimit = 3;
+
     var srcBucket = event.Records[0].s3.bucket.name;
     var srcKey = decodeURIComponent(event.Records[0].s3.object.key.replace(/\+/g, ' '));
     var keyComponents = srcKey.split('/');
     var service = keyComponents[keyComponents.length - 2];
     var filename = keyComponents[keyComponents.length - 1];
     var parser = parsers[service];
-    if (!parser) return callback(new Error('no parser for: ' + service));
+    if (!parser) {
+      return callback(new Error('Error: no parser for ' + service + '\nS3Key: ' + srcKey));
+    }
 
-    console.log('fetching ' + srcKey);
     s3.getObject({ Bucket: srcBucket, Key: srcKey }, function getS3Object(err, data) {
-      if (err) return callback(err);
+      if (err) return callback(new Error('Error: s3 get failed with ' + err.message));
       var lines = data.Body.toString().split('\n');
-      console.log('retrieved ' + lines.length + ' lines');
       var formatted = [];
       lines.forEach(function (line) {
         if (!line) return;
         formatted.push(formatter(parser(line)));
       });
-      exporter.addBatch(formatted);
-
-      // send log files to legacy parsing location
-      // (will be removed once the legacy system is shut down)
-      s3.copyObject({
-        Bucket: destBucket,
-        CopySource: srcBucket + '/' + event.Records[0].s3.object.key,
-        Key: destPrefix + '/' + service + '/' + filename
-      }, function (copyerr) {
-        if (copyerr) {
-          console.error(copyerr);
-          return callback(copyerr);
+      exporter.addBatch(formatted, function (exporterr, exportresult) {
+        if (exporterr) {
+          var newerr = new Error('Error: exporter.addBatch failed for ' + srcKey +
+                                 '\n' + exporterr.message);
+          newerr.stack = exporterr.stack + '\n' + newerr.stack;
+          return callback(newerr);
         }
-        s3.deleteObject({
-          Bucket: srcBucket,
-          Key: event.Records[0].s3.object.key
-        }, function (deleteerr) {
-          if (err) {
-            console.error(deleteerr);
-            return callback(deleteerr);
+
+        // send log files to legacy parsing location
+        // (will be removed once the legacy system is shut down)
+        s3.copyObject({
+          Bucket: destBucket,
+          CopySource: srcBucket + '/' + event.Records[0].s3.object.key,
+          Key: destPrefix + '/' + service + '/' + filename
+        }, function (copyerr) {
+          if (copyerr) {
+            console.error('Error: s3 copy failed for ' + srcKey + '\n' + copyerr.message);
+            return callback(null);
           }
-          callback();
+          s3.deleteObject({
+            Bucket: srcBucket,
+            Key: event.Records[0].s3.object.key
+          }, function (deleteerr) {
+            if (err) {
+              console.error('Error: s3 delete failed for ' + srcKey + '\n' + deleteerr.message);
+            } else {
+              console.log('Loaded ' + srcKey + ' and ' + exportresult);
+            }
+            callback(null);
+          });
         });
       });
     });

--- a/test/exporters/kinesisExporter.js
+++ b/test/exporters/kinesisExporter.js
@@ -28,10 +28,12 @@ describe('kinesisExporter', function () {
       });
       var exporter = new KinesisExporter({ region: 'oz', streamName: 'teststream' });
 
-      exporter.add('payload');
-      expect(stubs.putRecord.firstCall.args[0]).to.deep.equal({
-        DeliveryStreamName: 'teststream',
-        Record: { Data: 'payload\n' }
+      exporter.add('payload', function (err) {
+        expect(err).to.not.exist;
+        expect(stubs.putRecord.firstCall.args[0]).to.deep.equal({
+          DeliveryStreamName: 'teststream',
+          Record: { Data: 'payload\n' }
+        });
       });
     });
   });
@@ -44,10 +46,12 @@ describe('kinesisExporter', function () {
       });
       var exporter = new KinesisExporter({ region: 'oz', streamName: 'teststream' });
 
-      exporter.addBatch(['payload']);
-      expect(stubs.putRecordBatch.firstCall.args[0]).to.deep.equal({
-        DeliveryStreamName: 'teststream',
-        Records: [{ Data: 'payload\n' }]
+      exporter.addBatch(['payload'], function (err) {
+        expect(err).to.not.exist;
+        expect(stubs.putRecordBatch.firstCall.args[0]).to.deep.equal({
+          DeliveryStreamName: 'teststream',
+          Records: [{ Data: 'payload\n' }]
+        });
       });
     });
 
@@ -63,13 +67,19 @@ describe('kinesisExporter', function () {
         rows.push('a');
       }
 
-      exporter.addBatch(rows);
-      expect(stubs.putRecordBatch.firstCall.args[0].Records.length).to.equal(500);
-      expect(stubs.putRecordBatch.secondCall.args[0]).to.deep.equal({
-        DeliveryStreamName: 'teststream',
-        Records: [{ Data: 'a\n' }]
+      exporter.addBatch(rows, function (err) {
+        expect(err).to.not.exist;
+        console.log('a');
+        expect(stubs.putRecordBatch.firstCall.args[0].Records.length).to.equal(500);
+        console.log('b');
+        expect(stubs.putRecordBatch.secondCall.args[0]).to.deep.equal({
+          DeliveryStreamName: 'teststream',
+          Records: [{ Data: 'a\n' }]
+        });
+        console.log('c');
+        expect(stubs.putRecordBatch.calledTwice).to.be.true;
+        console.log('d');
       });
-      expect(stubs.putRecordBatch.calledTwice).to.be.true;
     });
   });
 });

--- a/test/processors/lambdaS3.js
+++ b/test/processors/lambdaS3.js
@@ -49,8 +49,8 @@ var s3BadEvent = {
 };
 
 function stubConfig() {
-  var exporteradd = sinon.spy();
-  var exporteraddbatch = sinon.spy();
+  var exporteradd = sinon.stub().callsArgWith(1, null);
+  var exporteraddbatch = sinon.stub().callsArgWith(1, null);
   var exporter = { add: exporteradd, addBatch: exporteraddbatch };
   var parser = sinon.stub().returns('parsed');
   var formatter = sinon.stub().returns('formatted');


### PR DESCRIPTION
improve the searchability and usefulness of the logging we're doing to cloudwatch in our lambda function.
also for errors that leave things in an uncertain state, just log the error and don't retry. this will be a little bit hard to detect, but it should manifest itself in logfiles piling up in s3